### PR TITLE
navigation fix

### DIFF
--- a/src/client/components/sidebar/SidebarNavLinks.svelte
+++ b/src/client/components/sidebar/SidebarNavLinks.svelte
@@ -1,6 +1,4 @@
 <script>
-  import { preventDefault } from 'svelte/legacy'
-
   /**
    * @typedef {Object} Props
    * @property {any} href
@@ -11,13 +9,23 @@
   /** @type {Props} */
   let { href, selected, text } = $props()
 
-  function handleClick() {
+  function handleClick(event) {
+    if (
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return
+    }
+    event.preventDefault()
     globalThis.history.pushState({}, '', href)
   }
 </script>
 
 <!-- prettier-ignore -->
-<a {href} class="component_link" class:selected onclick={preventDefault(handleClick)}>
+<a {href} class="component_link" class:selected onclick={handleClick}>
   <div class="component_link-container">
     <div class="component_dot"></div>
     <div class="component_icon">

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -53,20 +53,31 @@ export function findRoute(url) {
 ;(function (history) {
   if (!history) return
   var pushState = history.pushState
+  var replaceState = history.replaceState
   history.pushState = function (state, title, url) {
+    const rawUrl = typeof url === 'string' ? url : ''
+    let nextPath = rawUrl
+    if (baseurl.length > 0 && nextPath.startsWith(baseurl)) {
+      nextPath = nextPath.substring(baseurl.length) || '/'
+    }
+    if (nextPath.length === 0) nextPath = '/'
+    if (nextPath[0] !== '/') nextPath = '/' + nextPath
+
+    currentUrl = baseurl + nextPath
+    const nextState = state && typeof state === 'object' ? state : {}
     // @ts-ignore
-    if (url.startsWith(baseurl) && baseurl.length > 0) return // TODO check this line
-    currentUrl = baseurl + url
-    state.url = currentUrl
+    nextState.url = currentUrl
     if (
-      state.url !== history.state.url ||
-      state.selectedExample !== history.state.selectedExample
+      // @ts-ignore
+      nextState.url !== history.state?.url ||
+      // @ts-ignore
+      nextState.selectedExample !== history.state?.selectedExample
     ) {
-      dispatchUpdateRoute(state, currentUrl)
-      return pushState.apply(history, [state, '', currentUrl])
+      dispatchUpdateRoute(nextState, currentUrl)
+      return pushState.apply(history, [nextState, '', currentUrl])
     } else {
-      dispatchUpdateRoute(state, currentUrl)
-      window.location.reload()
+      dispatchUpdateRoute(nextState, currentUrl)
+      return replaceState.apply(history, [nextState, '', currentUrl])
     }
   }
 })(globalThis.history)


### PR DESCRIPTION
removed hard reload when navigating to the same url, and prevents default navigation on links only on unmodified left click

I noticed this when navigating to the same example that was already open, which refreshed the whole page. This change allows for more SPA-like behavior.