### PR TITLE
fix collapsing/expanding folders when example is selected

### DIFF
--- a/src/client/GardenApp.svelte
+++ b/src/client/GardenApp.svelte
@@ -47,6 +47,7 @@
     rootNodesExpanded,
     toggleFolder,
     toggleRootFolders,
+    navigateToLeafNode,
     filterNavTree,
     updateFilter,
     updateNavTree,
@@ -102,6 +103,7 @@
 
   function openInTab() {
     const targetWindow = window.open('/frame.html', '_blank')
+    if (!targetWindow) return
     targetWindow.onload = () => {
       targetWindow.postMessage(
         {
@@ -177,6 +179,7 @@
         onToggleOrientation={toggleOrientation}
         onToggleShowGrid={toggleShowGrid}
         onToggleShowInspector={toggleShowInspector}
+        onRevealInExplorer={() => navigateToLeafNode($selectedNode?.href)}
       />
       <Stage
         appTheme={$appTheme}

--- a/src/client/components/topbar/Topbar.svelte
+++ b/src/client/components/topbar/Topbar.svelte
@@ -25,6 +25,7 @@
     onToggleOrientation,
     onToggleShowGrid,
     onToggleShowInspector,
+    onRevealInExplorer,
   } = $props()
 
   let dark = $state(false)
@@ -38,6 +39,10 @@
       document.documentElement.setAttribute('data-theme', 'dark')
     else document.documentElement.setAttribute('data-theme', 'light')
   })
+
+  function revealInExplorer() {
+    onRevealInExplorer()
+  }
 </script>
 
 <!-- prettier-ignore -->
@@ -60,6 +65,10 @@
         {:else }
           <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
         {/if}
+      </button>
+      <button class="topbar_btn reveal_btn" onclick={revealInExplorer} title="Reveal in explorer">
+        <span class="is-hidden">Reveal in explorer</span>
+        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 5h13"></path><path d="M13 12h8"></path><path d="M13 19h8"></path><path d="M3 10a2 2 0 0 0 2 2h3"></path><path d="M3 5v12a2 2 0 0 0 2 2h3"></path></svg>
       </button>
       {/if}
     </div>
@@ -211,12 +220,14 @@
 
   /* remove btns on small screens */
   @media (max-height: 499px) {
-    .bookmark_btn {
+    .bookmark_btn,
+    .reveal_btn {
       display: none;
     }
   }
   @media (max-width: 499px) {
     .bookmark_btn,
+    .reveal_btn,
     .openexternal_btn {
       display: none;
     }

--- a/src/client/logic/navTree.js
+++ b/src/client/logic/navTree.js
@@ -132,6 +132,29 @@ function isUnfolded(node, route, filter, visible) {
   )
 }
 
+function normalizeHref(href) {
+  return href.split('#')[0].split('?')[0].replace(/\/+$/, '')
+}
+
+export function navigateToLeafNode(href) {
+  const targetHref = normalizeHref(href)
+
+  const all = navtree.flatMap(getAllNodes)
+  const leaf = all.find((n) => n.isLeaf && normalizeHref(n.href) === targetHref)
+
+  const hrefToUse = normalizeHref(leaf?.href) || targetHref
+  const parts = hrefToUse.split('/').filter((p) => p.length > 0)
+  if (parts.length < 2) return leaf
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = '/' + parts.slice(0, i + 1).join('/') + '/'
+    unfoldedNodes[key] = true
+  }
+
+  rootNodesExpanded.set(true)
+  updateTree()
+}
+
 export function toggleRootFolders() {
   rootNodesExpanded.set(!get(rootNodesExpanded))
   const newNodes = get(nodes).map((n) => ({


### PR DESCRIPTION
Fixed a bug where folders could not be expanded/collapsed.

How to recreate:

1. select an example
2. click on a parent folder of the example
3. it does not collapse the folder

After the fix, it collapses as expected.