### PR TITLE
feature: parameters

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,9 +2,11 @@ import prettier from 'eslint-config-prettier'
 import { includeIgnoreFile } from '@eslint/compat'
 import js from '@eslint/js'
 import svelte from 'eslint-plugin-svelte'
+import tseslint from '@typescript-eslint/eslint-plugin'
 import globals from 'globals'
 import { fileURLToPath } from 'node:url'
 import svelteConfig from './svelte.config.js'
+import tsParser from '@typescript-eslint/parser'
 
 const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url))
 
@@ -25,6 +27,17 @@ export default [
   },
   {
     files: ['**/*.svelte', '**/*.svelte.js'],
-    languageOptions: { parserOptions: { svelteConfig } },
+    languageOptions: { parserOptions: { svelteConfig, parser: tsParser } },
+  },
+  {
+    files: ['**/*.svelte'],
+    plugins: { '@typescript-eslint': tseslint },
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
   },
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gardenjs",
-  "version": "1.6.2",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gardenjs",
-      "version": "1.6.2",
+      "version": "1.6.5",
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "1.5.0",
@@ -28,6 +28,8 @@
         "@eslint/compat": "1.2.5",
         "@sveltejs/vite-plugin-svelte": "6.1.0",
         "@types/node": "25.0.1",
+        "@typescript-eslint/eslint-plugin": "^8.52.0",
+        "@typescript-eslint/parser": "^8.52.0",
         "eslint": "9.31.0",
         "eslint-config-prettier": "10.1.5",
         "eslint-plugin-svelte": "3.11.0",
@@ -40,10 +42,11 @@
         "vite": "7.0.5"
       },
       "peerDependencies": {
+        "tsx": "^4.21.0",
         "typescript": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "ts-node": {
+        "tsx": {
           "optional": true
         },
         "typescript": {
@@ -530,9 +533,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -562,9 +565,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2004,6 +2007,262 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
+      "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/type-utils": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.52.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
+      "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
+      "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.52.0",
+        "@typescript-eslint/types": "^8.52.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
+      "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
+      "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
+      "integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
+      "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
+      "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.52.0",
+        "@typescript-eslint/tsconfig-utils": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
+      "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
+      "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.52.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2468,9 +2727,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4628,9 +4887,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4906,13 +5165,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4922,10 +5181,13 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -4985,6 +5247,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-node": {
@@ -5059,11 +5334,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@eslint/compat": "1.2.5",
     "@sveltejs/vite-plugin-svelte": "6.1.0",
     "@types/node": "25.0.1",
+    "@typescript-eslint/eslint-plugin": "^8.52.0",
+    "@typescript-eslint/parser": "^8.52.0",
     "eslint": "9.31.0",
     "eslint-config-prettier": "10.1.5",
     "eslint-plugin-svelte": "3.11.0",

--- a/src/client/GardenFrame.svelte
+++ b/src/client/GardenFrame.svelte
@@ -54,8 +54,14 @@
     showGrid = evt.data.showGrid === true
     gridSettings = evt.data.gridSettings
     das = dasMap[evt.data.componentName]
-    selectedExample =
+    const rawSelectedExample =
       das?.examples?.find((ex) => ex.title === evt.data.selectedExample) ?? {}
+    const argsFromMessage =
+      evt.data?.args && typeof evt.data.args === 'object' ? evt.data.args : {}
+    selectedExample = {
+      ...rawSelectedExample,
+      input: { ...(rawSelectedExample?.input ?? {}), ...argsFromMessage },
+    }
     componentChanged = componentName !== evt.data.componentName
     componentName = evt.data.componentName || 'Welcome'
     selectedExampleChanged = selectedExampleTitle !== evt.data.selectedExample

--- a/src/client/components/stage/panel/PanelParams.svelte
+++ b/src/client/components/stage/panel/PanelParams.svelte
@@ -1,0 +1,95 @@
+<script>
+  import BooleanParam from './params/BooleanParam.svelte'
+  import NumberParam from './params/NumberParam.svelte'
+  import TextInputParam from './params/TextInputParam.svelte'
+
+  let { params = [], values = {}, onChange, onReset } = $props()
+
+  const getParamType = (param) => String(param?.type ?? '').toLowerCase()
+</script>
+
+<div class="params">
+  <div class="header">
+    <div class="title">Parameters</div>
+    <button class="reset" onclick={() => onReset?.()}>Reset</button>
+  </div>
+
+  {#if params.length === 0}
+    <div class="empty">No parameters defined.</div>
+  {:else}
+    <div class="grid">
+      {#each params as param (param.name)}
+        {@const paramType = getParamType(param)}
+
+        <div class="row">
+          <div class="label">
+            {param.name}
+          </div>
+
+          <div class="input">
+            {#if paramType === 'boolean'}
+              <BooleanParam
+                value={values?.[param.name] ?? false}
+                onChange={(v) => onChange?.(param.name, v)}
+              />
+            {:else if paramType === 'number'}
+              <NumberParam
+                value={values?.[param.name] ?? 0}
+                onChange={(v) => onChange?.(param.name, v)}
+              />
+            {:else}
+              <TextInputParam
+                value={values?.[param.name] ?? ''}
+                onChange={(v) => onChange?.(param.name, v)}
+              />
+            {/if}
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+  .title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--c-basic-800);
+  }
+  .reset {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.8rem;
+    background: var(--c-basic-100);
+    border-radius: 0.375rem;
+    color: var(--c-basic-800);
+  }
+  .reset:hover,
+  .reset:focus-visible {
+    background: var(--c-basic-150);
+    color: var(--c-primary);
+  }
+  .empty {
+    color: var(--c-basic-600);
+    font-size: 0.9rem;
+  }
+  .grid {
+    display: grid;
+    gap: 0.75rem;
+  }
+  .row {
+    display: grid;
+    grid-template-columns: minmax(120px, 220px) 1fr;
+    gap: 0.75rem;
+    align-items: center;
+  }
+  .label {
+    font-size: 0.85rem;
+    color: var(--c-basic-700);
+  }
+</style>

--- a/src/client/components/stage/panel/params/BooleanParam.svelte
+++ b/src/client/components/stage/panel/params/BooleanParam.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import ParamType from './ParamType.svelte'
+  import type { ComponentProps } from 'svelte'
+
+  let {
+    value = $bindable(false),
+    onChange,
+  }: Omit<ComponentProps<typeof ParamType>, 'children'> = $props()
+</script>
+
+<ParamType {onChange} bind:value>
+  {#snippet children(setValue)}
+    <input
+      type="checkbox"
+      checked={value === true}
+      onchange={(e) => setValue((e.currentTarget as HTMLInputElement).checked)}
+    />
+  {/snippet}
+</ParamType>
+
+<style>
+  :global(.param_type input[type='checkbox']) {
+    border: 1px solid var(--c-basic-150);
+    border-radius: 0.375rem;
+    background: var(--c-basic-0);
+    color: var(--c-basic-800);
+  }
+</style>

--- a/src/client/components/stage/panel/params/NumberParam.svelte
+++ b/src/client/components/stage/panel/params/NumberParam.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import ParamType from './ParamType.svelte'
+  import type { ComponentProps } from 'svelte'
+
+  let {
+    value = $bindable(0),
+    onChange,
+  }: Omit<ComponentProps<typeof ParamType>, 'children'> = $props()
+</script>
+
+<ParamType {onChange} bind:value>
+  {#snippet children(setValue)}
+    <input
+      type="number"
+      value={value ?? 0}
+      oninput={(e) => {
+        const t = e.currentTarget as HTMLInputElement
+        const n = t.valueAsNumber
+        if (Number.isFinite(n)) setValue(n)
+      }}
+    />
+  {/snippet}
+</ParamType>
+
+<style>
+  :global(.param_type input[type='number']) {
+    width: 100%;
+    border: 1px solid var(--c-basic-150);
+    border-radius: 0.375rem;
+    background: var(--c-basic-0);
+    color: var(--c-basic-800);
+    -moz-appearance: auto;
+    appearance: auto;
+  }
+
+  :global(.param_type input[type='number']::-webkit-inner-spin-button),
+  :global(.param_type input[type='number']::-webkit-outer-spin-button) {
+    -webkit-appearance: auto;
+    margin: 0;
+  }
+</style>

--- a/src/client/components/stage/panel/params/ParamType.svelte
+++ b/src/client/components/stage/panel/params/ParamType.svelte
@@ -1,0 +1,28 @@
+<script lang="ts" generics="Value">
+  import type { Snippet } from 'svelte'
+
+  let {
+    onChange,
+    value = $bindable<Value>(),
+    children,
+  }: {
+    onChange: (_value: Value) => void
+    value: Value
+    children: Snippet<[setValue: (_v: Value) => void]>
+  } = $props()
+
+  const setValue = (v: Value) => {
+    value = v
+    onChange(v)
+  }
+</script>
+
+<div class="param_type">
+  {@render children(setValue)}
+</div>
+
+<style>
+  .param_type {
+    padding: 0.375rem 0.5rem;
+  }
+</style>

--- a/src/client/components/stage/panel/params/TextInputParam.svelte
+++ b/src/client/components/stage/panel/params/TextInputParam.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import ParamType from './ParamType.svelte'
+  import type { ComponentProps } from 'svelte'
+
+  let {
+    value = $bindable(''),
+    onChange,
+  }: Omit<ComponentProps<typeof ParamType>, 'children'> = $props()
+</script>
+
+<ParamType {onChange} bind:value>
+  {#snippet children(setValue)}
+    <input
+      type="text"
+      value={String(value ?? '')}
+      oninput={(e) =>
+        setValue(String((e.currentTarget as HTMLInputElement).value ?? ''))}
+    />
+  {/snippet}
+</ParamType>
+
+<style>
+  :global(.param_type input[type='text']) {
+    width: 100%;
+    border: 1px solid var(--c-basic-150);
+    border-radius: 0.375rem;
+    background: var(--c-basic-0);
+    color: var(--c-basic-800);
+  }
+</style>


### PR DESCRIPTION
Implements parameter tab for examples.

I did not add the "control" field for parameters, as only the "type" field seemed necessary for the job at this point. 

I also added typescript parsing for eslint in svelte files. Let me know if that's OK with you.

There is one caveat that I noticed with the current implementation, which is that the default state of the rendered component in the iframe doesn't necessarily correspond to the default state of the parameters. This is because currently there isn't an obvious way for the parameters to know what props the component initially receives. I think fixing this would require some architectural re-thinking, so I have not addressed it yet.