### PR TITLE
fix: only show params from current examples input.

### DIFF
--- a/src/client/components/stage/Stage.svelte
+++ b/src/client/components/stage/Stage.svelte
@@ -81,16 +81,7 @@
       []
     )
 
-    return [
-      ...exampleParams,
-      ...configuredParams
-        .filter((configuredParam) =>
-          exampleParams.every(
-            (exampleParam) => exampleParam.name !== configuredParam.name
-          )
-        )
-        .map((p) => ({ ...p, value: undefined })),
-    ]
+    return exampleParams
   })
 
   let paramValues = $derived(structuredClone(selectedExampleInput))


### PR DESCRIPTION
The parameters panel now only shows controls for props that exist in the currently selected example’s input. In Stage.svelte, the logic that appended all remaining das.params with value: undefined was removed; the panel now returns only exampleParams. Params are still auto-generated for keys in the current example. This avoids irrelevant or empty controls when examples use different props.